### PR TITLE
Update .build-script to point to correct directory

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -1,6 +1,6 @@
 composer install --no-dev
 
-cd content/plugins-mu/restsplain
+cd content/mu-plugins/restsplain
 git checkout master
 git pull
 cd ../../themes/broker-authentication


### PR DESCRIPTION
Resplain now resides under `content/mu-plugins` which requires the build script to be updated.